### PR TITLE
Added index to uid column

### DIFF
--- a/member.install
+++ b/member.install
@@ -68,6 +68,7 @@ function member_schema() {
       'created' => array('created'),
       'status' => array('status'),
       'name' => array('name'),
+      'uid' => array('uid'),
     ),
     'unique keys' => array(
       'uuid' => array('uuid'),

--- a/member.install
+++ b/member.install
@@ -78,3 +78,10 @@ function member_schema() {
   return $schema;
 
 }
+
+/**
+ * Add an index to the 'uid` column in the member table.
+ */
+function member_update_7101() {
+  db_add_index('member', 'uid', array('uid'));
+}


### PR DESCRIPTION
This table is frequently used as an intermediary to resolve Drupal user id to student record because it contains both `uid` and `uuid`. This index reduces some queries' execution time almost 300 times!
